### PR TITLE
Update phplist to v3.0.12

### DIFF
--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="2.10.19/phplist-2.10.19.tgz"
+VERSION="3.0.12/phplist-3.0.12.tgz"
 URL="http://sourceforge.net/projects/phplist/files/phplist/$VERSION"
 
 dl $URL /usr/local/src

--- a/conf.d/main
+++ b/conf.d/main
@@ -81,7 +81,8 @@ sed -i "s|^define (\"TEST\".*|define (\"TEST\",0);|" $CONFIG
 # curl based install
 URL="http://127.0.0.1/admin/?page=initialise&firstinstall=1"
 CURL="curl -c /tmp/cookie -b /tmp/cookie"
-$CURL $URL
+DATA="firstinstall=1&page=initialise&adminname=admin&orgname=TurnKey+Linux&adminemail=mail%40example.com&adminpassword=turnkeylinux"
+$CURL -d $DATA $URL
 rm -f /tmp/cookie
 
 # set default password for good measure

--- a/overlay/usr/lib/inithooks/bin/phplist.py
+++ b/overlay/usr/lib/inithooks/bin/phplist.py
@@ -72,9 +72,9 @@ def main():
         domain = DEFAULT_DOMAIN
 
     m = MySQL()
-    m.execute('UPDATE phplist.admin SET password=\"%s\" WHERE loginname=\"admin\";' % password)
-    m.execute('UPDATE phplist.admin SET email=\"%s\" WHERE loginname=\"admin\";' % email)
-    m.execute('UPDATE phplist.config SET value=\"%s\" WHERE item=\"website\";' % domain)
+    m.execute('UPDATE phplist.phplist_admin SET password=\"%s\" WHERE loginname=\"admin\";' % password)
+    m.execute('UPDATE phplist.phplist_admin SET email=\"%s\" WHERE loginname=\"admin\";' % email)
+    m.execute('UPDATE phplist.phplist_config SET value=\"%s\" WHERE item=\"website\";' % domain)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This updates to the latest version of phplist and adjusts the curl install command and the DB layout so the install works as it should.

Tested and working with v13.x
